### PR TITLE
モバイルUIにおいてサインアウトボタンを追加

### DIFF
--- a/app/web/app/components/MobileMenu/MobileMenu.tsx
+++ b/app/web/app/components/MobileMenu/MobileMenu.tsx
@@ -106,7 +106,7 @@ export function MobileMenu() {
 				)}
 			</NavLink>
 			<NavLink
-				to="/setting"
+				to="/setting/profile"
 				className={({ isActive }) =>
 					cn("flex flex-col items-center", isActive && "text-blue-900")
 				}

--- a/app/web/app/routes/_auth+/_layout.tsx
+++ b/app/web/app/routes/_auth+/_layout.tsx
@@ -1,19 +1,31 @@
 import { Outlet, Link as RouterLink } from "@remix-run/react";
 
-import { MobileMenu, SideMenu } from "~/components";
+import { Button, MobileMenu, SideMenu } from "~/components";
 
 export { profileLoader as loader } from "~/features/profile/loaders";
 
 export default function Auth() {
 	return (
 		<div className="grid grid-cols-12 justify-center container gap-6">
-			<header className="col-span-12 mt-3 md:my-5">
-				<RouterLink to="/" className="text-std-20N-150">
-					Datti
-				</RouterLink>
-				<p className="text-std-16N-170 hidden md:block">
-					誰にいくら払ったっけ？を記録するサービス
-				</p>
+			<header className="col-span-12 mt-3 md:my-5 flex align-middle justify-between">
+				<div className="">
+					<RouterLink to="/" className="text-std-20N-150">
+						Datti
+					</RouterLink>
+					<p className="text-std-16N-170 hidden md:block">
+						誰にいくら払ったっけ？を記録するサービス
+					</p>
+				</div>
+				<form action="/auth/signout" method="post">
+					<Button
+						type="submit"
+						variant="solid-fill"
+						size="sm"
+						className="bg-red-900 hover:bg-red-1000 active:bg-red-1100 md:hidden"
+					>
+						ログアウト
+					</Button>
+				</form>
 			</header>
 			<div className="hidden md:flex col-span-3 flex-col my-10">
 				<SideMenu />


### PR DESCRIPTION
## 機能概要
- モバイルUIにおいてヘッダー部分にサインアウトボタンを追加
- モバイルUIにおいて設定ボタン押下時に、プロフィール設定画面に遷移されるように修正