### PR TITLE
認証ミドルウェアのアクセストークン取得処理を修正

### DIFF
--- a/app/web/server/middlewares/authMiddleware.ts
+++ b/app/web/server/middlewares/authMiddleware.ts
@@ -1,21 +1,21 @@
 import { createMiddleware } from "hono/factory";
-import { HTTPException } from "hono/http-exception";
 import type { Env } from "server";
 import { createSupabase } from "server/utils/supabase";
 
 export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 	if (c.req.path !== "/signin") {
 		const supabase = createSupabase(c);
-		await supabase.auth.getUser();
+		const { error: getUserError } = await supabase.auth.getUser();
+		if (getUserError) {
+			return c.redirect("/signin");
+		}
 		const {
 			data: { session },
-			error,
+			error: getSessionError,
 		} = await supabase.auth.getSession();
 		const accessToken = session?.access_token;
-		if (error) {
-			throw new HTTPException(500, {
-				message: "failed to get accessToken",
-			});
+		if (getSessionError || accessToken === undefined) {
+			return c.redirect("/signin");
 		}
 		c.set("accessToken", accessToken);
 	}

--- a/app/web/server/middlewares/authMiddleware.ts
+++ b/app/web/server/middlewares/authMiddleware.ts
@@ -6,6 +6,7 @@ import { createSupabase } from "server/utils/supabase";
 export const authMiddleware = createMiddleware<Env>(async (c, next) => {
 	if (c.req.path !== "/signin") {
 		const supabase = createSupabase(c);
+		await supabase.auth.getUser();
 		const {
 			data: { session },
 			error,


### PR DESCRIPTION
closed #128

## 変更概要
- 認証ミドルウェアにおいてセッションからアクセストークンを取得する前にSupabase APIからユーザー情報を取得するように
- アクセストークンの取得処理に失敗したさいに、サインインページにリダイレクトさせるように